### PR TITLE
fix: avoid node-plop pulling in core-js

### DIFF
--- a/packages/init/command.js
+++ b/packages/init/command.js
@@ -1,4 +1,6 @@
-const nodePlop = require('node-plop');
+// Cherry pick to avoid pulling in all of core-js
+// see: https://github.com/plopjs/node-plop/pull/163
+const nodePlop = require('node-plop/lib/node-plop').default;
 
 // load an instance of plop from a plopfile
 


### PR DESCRIPTION
https://github.com/plopjs/node-plop/pull/163

Super annoying but webpack has its own `OrderedSet` class that extends the native `Set`. webpack 5 added a `addAll` method to this class, and WebpackCopyPlugin duck types webpack by checking for the existence of this `addAll` method. 

There is also a native proposal for `[[Set]].addAll` which core-js helpfully polyfills. `node-plop` pulls in all of `core-js`, thereby polyfilling Set and breaking the duck typing in the webpack copy plugin causing it to throw.